### PR TITLE
Refactor token balance retrieval and layout component

### DIFF
--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -84,9 +84,9 @@ const PickNetwork = () => {
 export default function Layout({
   children,
 }: Readonly<{ children: ReactNode }>) {
-  const { address } = useAccount();
+  const { address, chainId } = useAccount();
   const { usdcBalance } = useGetTokenBalances(address!, 1);
-  const chainId = use$(chain$.chainId);
+  // const chainId = use$(chain$.chainId);
   return (
     <SidebarProvider defaultOpen={false}>
       <AppSidebar />

--- a/hooks/use-get-token-blances.ts
+++ b/hooks/use-get-token-blances.ts
@@ -1,11 +1,12 @@
 'use client';
-import { USDC_CONTRACT } from '@/constants/contracts/contracts';
 import useEthersProvider from '@/services/blockchain/hooks/useEthersProvider';
 import { Contract, ethers } from 'ethers';
 import { useEffect, useState } from 'react';
+import { useSafeYieldsContract } from '@/services/blockchain/safeyields.contracts';
 
 export default function useGetTokenBalances(address: string, txUpdate: number) {
   const provider = useEthersProvider();
+  const {usdc} = useSafeYieldsContract();
 
   const [usdcBalance, setUsdcBalance] = useState(0);
   const [safeBalance, setSafeBalance] = useState(0);
@@ -16,10 +17,9 @@ export default function useGetTokenBalances(address: string, txUpdate: number) {
 
     const getBalances = async () => {
       try {
-        const USDC_CONTRACT_ = USDC_CONTRACT.connect(provider) as Contract;
         // const SAFE_CONTRACT_ = SAFE_CONTRACT.connect(provider) as Contract;
 
-        const usdcBalance_ = await USDC_CONTRACT_.balanceOf(address);
+        const usdcBalance_ = await usdc.balanceOf(address);
         console.log(usdcBalance_);
         setUsdcBalance(Number(ethers.formatUnits(usdcBalance_, 6)));
       } catch (err) {}


### PR DESCRIPTION
Refactor the `useGetTokenBalances` hook to use `useSafeYieldsContract` for retrieving USDC balances and update the `Layout` component to include `chainId` in the `useAccount` hook.